### PR TITLE
make z index of current element higher

### DIFF
--- a/src/client/app/components/App/Canvas/Canvas.jsx
+++ b/src/client/app/components/App/Canvas/Canvas.jsx
@@ -274,7 +274,7 @@ class Canvas extends React.Component {
             <div
               key={id}
               data-grid={localLayout[id]}
-              className={`${this.props.editors[id].type === 'text' ? 'canvas-high' : ''}`
+              className={`${this.props.currentWidget === id ? 'canvas-high' : ''}`
             }
             >
 

--- a/src/client/app/components/App/Canvas/canvas.scss
+++ b/src/client/app/components/App/Canvas/canvas.scss
@@ -31,7 +31,7 @@
 }
 
 .canvas-high {
-  z-index: 200;
+  z-index: 1000;
 }
 
 .react-grid-item {


### PR DESCRIPTION
This PR ensures that the z-index of the current text box is higher than the rest
<img width="1032" alt="screen shot 2018-07-22 at 1 40 15 pm" src="https://user-images.githubusercontent.com/5505598/43048386-d583008e-8db4-11e8-8aee-bba5151dba05.png">

Before your pull request is reviewed and merged, please ensure that:

* [x] there are no linting errors
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`

Thank you!
