### PR TITLE
Feature #314 - add window confirm for file deletion

### DIFF
--- a/client/src/app/components/App/Modal/PagesList/FolderRow/FolderRow.jsx
+++ b/client/src/app/components/App/Modal/PagesList/FolderRow/FolderRow.jsx
@@ -63,7 +63,7 @@ class FolderRow extends Component {
 
   deleteFolder = (e) => {
     e.stopPropagation();
-    if (confirm('Are you sure you want to delete this folder?')) {
+    if (confirm('Are you sure you want to delete this folder?')) { // eslint-disable-line no-restricted-globals
       this.props.deleteFolder(this.props.folder._id);
     }
   }

--- a/client/src/app/components/App/Modal/PagesList/PageRow/PageRow.jsx
+++ b/client/src/app/components/App/Modal/PagesList/PageRow/PageRow.jsx
@@ -27,7 +27,7 @@ function collect(_connect, monitor) {
 class PageRow extends Component {
   deletePage = (e) => {
     e.stopPropagation();
-    if (confirm('Are you sure you want to delete this file?')) {
+    if (confirm('Are you sure you want to delete this file?')) { // eslint-disable-line no-restricted-globals
       this.props.deletePage(this.props.page._id);
     }
   }


### PR DESCRIPTION
This PR confirms before user deletes files/folders
![sep-19-2018 20-35-17](https://user-images.githubusercontent.com/5505598/45762304-b6307c00-bc4b-11e8-848e-2cf828b92229.gif)

Before your pull request is reviewed and merged, please ensure that:

* [ ] there are no linting errors
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] **Make sure you have run the tests!!**

Thank you!
@estherhersh - for now I've added the default confirm template from browsers. If we want to upgrade the UI, can we have a new issue for it?