### PR TITLE
change default sizes

### DIFF
--- a/client/src/app/components/App/Canvas/Image/image.scss
+++ b/client/src/app/components/App/Canvas/Image/image.scss
@@ -160,9 +160,8 @@
 }
 
 .image__drop {
-  padding: $medium-padding;
-  // background-color: $lighter-gray;
-  margin: $medium-margin 20px $small-margin;
+  padding: $small-padding;
+  margin: 0 $medium-margin;
   border-radius: $medium-border-radius;
   border: 1px dashed $light-gray;
   color: $gray;
@@ -203,6 +202,10 @@
     flex-direction: row;
     flex: 1;
   }
+}
+
+.element-image input {
+  width: 100%;
 }
 
 .image-reupload-form {

--- a/client/src/app/constants/widgetConstants.js
+++ b/client/src/app/constants/widgetConstants.js
@@ -5,7 +5,7 @@ export const TEXT_DEFAULT_WIDTH = 30;
 export const TEXT_MIN_WIDTH = 2;
 export const TEXT_MIN_HEIGHT = 2;
 
-export const IFRAME_DEFAULT_WIDTH = 30;
+export const IFRAME_DEFAULT_WIDTH = 15;
 export const IFRAME_MIN_WIDTH = 10;
 export const IFRAME_MIN_HEIGHT = 12;
 
@@ -13,7 +13,7 @@ export const CODE_DEFAULT_WIDTH = 30;
 export const CODE_MIN_WIDTH = 13;
 export const CODE_MIN_HEIGHT = 11;
 
-export const QUESTION_DEFAULT_WIDTH = 30;
+export const QUESTION_DEFAULT_WIDTH = 15;
 export const QUESTION_MIN_WIDTH = 6;
 export const QUESTION_MIN_HEIGHT = 5;
 
@@ -21,8 +21,8 @@ export const IMAGE_DEFAULT_HEIGHT = 12;
 export const IMAGE_DEFAULT_WIDTH = 12;
 export const IMAGE_MIN_WIDTH = 6;
 export const IMAGE_MIN_HEIGHT = 5;
-export const IMAGE_RESPONSIVE_TRIGGER_HEIGHT = 260;
-export const IMAGE_RESPONSIVE_TRIGGER_WIDTH = 280;
+export const IMAGE_RESPONSIVE_TRIGGER_HEIGHT = 200;
+export const IMAGE_RESPONSIVE_TRIGGER_WIDTH = 160;
 
 export const EDITOR_THEME = {
   light: 'base16-light',


### PR DESCRIPTION
This PR has the following changes - 
* Reduces the default width of Questions and Embeds by half - fixes #461 
* Reduce the transition image for image reupload design - fixes #462 
* Remove the extra blue outline on the image reupload design 
**Previous:**
<img width="394" alt="screen shot 2018-09-20 at 11 45 51 am" src="https://user-images.githubusercontent.com/5505598/45865618-bd669f80-bd9b-11e8-9a52-a41f3621c2d6.png">
**In this PR**
<img width="318" alt="screen shot 2018-09-21 at 12 42 19 pm" src="https://user-images.githubusercontent.com/5505598/45865643-d0796f80-bd9b-11e8-93d5-ee447a86672e.png">

Before your pull request is reviewed and merged, please ensure that:
* [ ] there are no linting errors
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master.
 **If you're asked to make more changes, make sure you rebase onto master then too!**
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] **Make sure you have run the tests!!**

Thank you!
