### PR TITLE
#484 : Add rollover text

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11549,6 +11549,16 @@
         "react-is": "16.4.2"
       }
     },
+    "react-tooltip": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.9.0.tgz",
+      "integrity": "sha512-vpn738FVv2oe2LzdwUchped3WqLgZSQwrBow+ceChS1+lFEJBPjOa9KD3JH/L/s0Aorxawi3A20qBcHX7vqaag==",
+      "requires": {
+        "classnames": "2.2.6",
+        "prop-types": "15.6.2",
+        "sanitize-html-react": "1.13.0"
+      }
+    },
     "react-visibility-sensor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-4.0.0.tgz",
@@ -11760,6 +11770,11 @@
         "extend-shallow": "3.0.2",
         "safe-regex": "1.1.0"
       }
+    },
+    "regexp-quote": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
+      "integrity": "sha1-Hg9GUMhi3L/tVP1CsUjpuxch/PI="
     },
     "regexpp": {
       "version": "2.0.0",
@@ -12148,6 +12163,23 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        }
+      }
+    },
+    "sanitize-html-react": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html-react/-/sanitize-html-react-1.13.0.tgz",
+      "integrity": "sha1-51e5rbryyKdi89Lf9wE4g44FQgo=",
+      "requires": {
+        "htmlparser2": "3.9.2",
+        "regexp-quote": "0.0.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.1.1",
     "react-split-pane": "^0.1.74",
+    "react-tooltip": "^3.9.0",
     "react-visibility-sensor": "^4.0.0",
     "reduce-reducers": "^0.4.3",
     "redux": "^3.7.2",

--- a/client/src/app/components/App/Canvas/WidgetNav/WidgetNav.jsx
+++ b/client/src/app/components/App/Canvas/WidgetNav/WidgetNav.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import PropTypes from 'prop-types';
 import CloseSVG from '../../../../images/close.svg';
 import CopySVG from '../../../../images/copy.svg';
 import DragSVG from '../../../../images/drag.svg';
+import * as descriptions from '../../../../constants/imageDescConstants.js';
 
 require('./widgetNav.scss');
 
@@ -18,15 +20,27 @@ class WidgetNav extends React.Component {
   render() {
     return (
       <nav className="widget__nav">
-        <button className="widget__close" onClick={this.duplicateEditor.bind(this)}>
+        <ReactTooltip
+          delayShow={descriptions.SHOW_DESC_DELAY}
+        />
+        <button
+          className="widget__close"
+          onClick={this.duplicateEditor.bind(this)}
+          data-tip={descriptions.WIDGET_DUPLICATE_DESC}
+        >
           <CopySVG alt="duplicate widget" />
         </button>
         <button
           className={`widget__close widget__drag drag__${this.props.id}`}
+          data-tip={descriptions.WIDGET_DRAG_DESC}
         >
           <DragSVG alt="drag widget" />
         </button>
-        <button className="widget__close" onClick={this.removeEditor.bind(this)}>
+        <button
+          className="widget__close"
+          onClick={this.removeEditor.bind(this)}
+          data-tip={descriptions.WIDGET_DELETE_DESC}
+        >
           <CloseSVG alt="close element" />
         </button>
       </nav>

--- a/client/src/app/components/App/Canvas/WidgetNav/WidgetNav.jsx
+++ b/client/src/app/components/App/Canvas/WidgetNav/WidgetNav.jsx
@@ -22,6 +22,7 @@ class WidgetNav extends React.Component {
       <nav className="widget__nav">
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
+className="tooltip"
         />
         <button
           className="widget__close"

--- a/client/src/app/components/App/Canvas/WidgetNav/WidgetNav.jsx
+++ b/client/src/app/components/App/Canvas/WidgetNav/WidgetNav.jsx
@@ -22,7 +22,7 @@ class WidgetNav extends React.Component {
       <nav className="widget__nav">
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
-className="tooltip"
+          className="tooltip"
         />
         <button
           className="widget__close"

--- a/client/src/app/components/App/MainToolbar/MainToolbar.jsx
+++ b/client/src/app/components/App/MainToolbar/MainToolbar.jsx
@@ -30,14 +30,14 @@ class MainToolbar extends React.Component {
     }, 10000);
   }
 
-  componentWillUnmount() {
-    clearTimeout(this.autoSaveTimeout);
-  }
-
   componentDidUpdate(prevProps) {
     if (prevProps.name !== this.props.name || prevProps.preview !== this.props.preview) {
       ReactTooltip.rebuild();
     }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.autoSaveTimeout);
   }
 
   logout = () => {
@@ -88,7 +88,7 @@ class MainToolbar extends React.Component {
       <div className="main-toolbar__container">
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
-className="tooltip"
+          className="tooltip"
         />
 
         <div className="main-toolbar">

--- a/client/src/app/components/App/MainToolbar/MainToolbar.jsx
+++ b/client/src/app/components/App/MainToolbar/MainToolbar.jsx
@@ -88,6 +88,7 @@ class MainToolbar extends React.Component {
       <div className="main-toolbar__container">
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
+className="tooltip"
         />
 
         <div className="main-toolbar">

--- a/client/src/app/components/App/MainToolbar/MainToolbar.jsx
+++ b/client/src/app/components/App/MainToolbar/MainToolbar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -11,6 +12,7 @@ import ToolbarLogo from '../../../images/logo.svg';
 import CheckSVG from '../../../images/check.svg';
 import AccountSVG from '../../../images/account.svg';
 import PreferencesSVG from '../../../images/preferences.svg';
+import * as descriptions from '../../../constants/imageDescConstants.js';
 
 require('./mainToolbar.scss');
 
@@ -30,6 +32,12 @@ class MainToolbar extends React.Component {
 
   componentWillUnmount() {
     clearTimeout(this.autoSaveTimeout);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.name !== this.props.name || prevProps.preview !== this.props.preview) {
+      ReactTooltip.rebuild();
+    }
   }
 
   logout = () => {
@@ -78,6 +86,9 @@ class MainToolbar extends React.Component {
 
     return (
       <div className="main-toolbar__container">
+        <ReactTooltip
+          delayShow={descriptions.SHOW_DESC_DELAY}
+        />
 
         <div className="main-toolbar">
           <div className="main-toolbar__div-left">
@@ -145,9 +156,13 @@ class MainToolbar extends React.Component {
             onChange={this.props.setPageTitle}
             readOnly={this.props.preview}
           />
-          {this.props.preview ||
-            <span className="fa fa-pencil-alt main-toolbar__search-icon"></span>
-          }
+          {this.props.preview || (
+            <span
+              className="fa fa-pencil-alt main-toolbar__search-icon"
+              data-tip={descriptions.MAIN_TOOLBAR_TITLE_DESC}
+            >
+            </span>
+          )}
           <div className="main-toolbar__div-right">
             <div className="main-toolbar__div-right-inside">
               <span className="main-toolbar__preview-title">Edit Mode</span>
@@ -173,6 +188,7 @@ class MainToolbar extends React.Component {
                 <button
                   className="main-toolbar__button "
                   onMouseDown={this.props.togglePreferencesPanel}
+                  data-tip={descriptions.MAIN_TOOLBAR_SETTINGS_DESC}
                 >
                   <PreferencesSVG
                     className={classNames(prefButtonClassName)}
@@ -196,6 +212,7 @@ class MainToolbar extends React.Component {
                       }, 50);
                     }}
                     className="main-toolbar__account-button"
+                    data-tip={descriptions.MAIN_TOOLBAR_ACCOUNT_DESC}
                     data-test="account-button"
                   >
                     <AccountSVG

--- a/client/src/app/components/App/Navigation/Navigation.jsx
+++ b/client/src/app/components/App/Navigation/Navigation.jsx
@@ -41,7 +41,7 @@ class Navigation extends React.Component {
       <div>
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
-className="tooltip"
+          className="tooltip"
         />
         <button
           className="navigation__open-button"

--- a/client/src/app/components/App/Navigation/Navigation.jsx
+++ b/client/src/app/components/App/Navigation/Navigation.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import * as navigationAction from '../../../action/navigation.js';
+import * as descriptions from '../../../constants/imageDescConstants.js';
 
 require('./navigation.scss');
 
@@ -25,6 +27,9 @@ class Navigation extends React.Component {
     if (prevProps.yNavigation !== this.props.yNavigation) {
       this.forceUpdate();
     }
+    if (prevProps.isNavigationOpen !== this.props.isNavigationOpen) {
+      ReactTooltip.rebuild();
+    }
   }
 
   scrollTo=(y) => {
@@ -34,9 +39,13 @@ class Navigation extends React.Component {
   render() {
     return (
       <div>
+        <ReactTooltip
+          delayShow={descriptions.SHOW_DESC_DELAY}
+        />
         <button
           className="navigation__open-button"
           onClick={this.props.openNavigationContent}
+          data-tip={descriptions.WIDGET_NAV_DESC}
         >
           <i className="fas fa-bars"></i>
         </button>
@@ -49,13 +58,18 @@ class Navigation extends React.Component {
                 <button
                   className="navigation__option-button"
                   onClick={() => { this.props.createNavigationContent(this.props.layout); }}
+                  data-tip={descriptions.WIDGET_NAV_REFRESH_DESC}
                 >
                   <i className="fas fa-redo"></i>
                 </button>
               )}
               <button
                 className="navigation__option-button"
-                onClick={this.props.closeNavigationContent}
+                onClick={() => {
+                  this.props.closeNavigationContent();
+                  ReactTooltip.hide();
+                }}
+                data-tip={descriptions.WIDGET_NAV_CLOSE_DESC}
               >
                 <i className="fas fa-times"></i>
               </button>

--- a/client/src/app/components/App/Navigation/Navigation.jsx
+++ b/client/src/app/components/App/Navigation/Navigation.jsx
@@ -41,6 +41,7 @@ class Navigation extends React.Component {
       <div>
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
+className="tooltip"
         />
         <button
           className="navigation__open-button"

--- a/client/src/app/components/App/Shared/EditorComponents/ConsoleOutput/ConsoleOutput.jsx
+++ b/client/src/app/components/App/Shared/EditorComponents/ConsoleOutput/ConsoleOutput.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import PropTypes from 'prop-types';
 import ReactHtmlParser from 'react-html-parser';
 
+import * as descriptions from '../../../../../constants/imageDescConstants.js';
 
 require('./consoleOutput.scss');
 
@@ -10,11 +12,15 @@ class ConsoleOutput extends React.Component {
     const toggleButton = this.props.isConsoleOpen ? '&or;' : '&and;';
     return (
       <div className="console__outputDiv">
+        <ReactTooltip
+          delayShow={descriptions.SHOW_DESC_DELAY}
+        />
         <nav className="console__nav">
           <p className="console__heading"> Console </p>
           <button
             className="console__toggle"
             onClick={this.props.toggleConsole}
+            data-tip={descriptions.EDITOR_TOGGLE_CONSOLE_DESC}
           >
             {ReactHtmlParser(toggleButton)}
           </button>

--- a/client/src/app/components/App/Shared/EditorComponents/ConsoleOutput/ConsoleOutput.jsx
+++ b/client/src/app/components/App/Shared/EditorComponents/ConsoleOutput/ConsoleOutput.jsx
@@ -14,7 +14,7 @@ class ConsoleOutput extends React.Component {
       <div className="console__outputDiv">
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
-className="tooltip"
+          className="tooltip"
         />
         <nav className="console__nav">
           <p className="console__heading"> Console </p>

--- a/client/src/app/components/App/Shared/EditorComponents/ConsoleOutput/ConsoleOutput.jsx
+++ b/client/src/app/components/App/Shared/EditorComponents/ConsoleOutput/ConsoleOutput.jsx
@@ -14,6 +14,7 @@ class ConsoleOutput extends React.Component {
       <div className="console__outputDiv">
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
+className="tooltip"
         />
         <nav className="console__nav">
           <p className="console__heading"> Console </p>

--- a/client/src/app/components/App/Shared/EditorComponents/EditorToolbar/EditorToolbar.jsx
+++ b/client/src/app/components/App/Shared/EditorComponents/EditorToolbar/EditorToolbar.jsx
@@ -91,6 +91,7 @@ class EditorToolbar extends React.Component {
       <div className='editor-toolbar__container'>
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
+className="tooltip"
         />
         <div className='editor-toolbar__button-container'>
           {(this.props.editorMode === 'processing') && (

--- a/client/src/app/components/App/Shared/EditorComponents/EditorToolbar/EditorToolbar.jsx
+++ b/client/src/app/components/App/Shared/EditorComponents/EditorToolbar/EditorToolbar.jsx
@@ -91,7 +91,7 @@ class EditorToolbar extends React.Component {
       <div className='editor-toolbar__container'>
         <ReactTooltip
           delayShow={descriptions.SHOW_DESC_DELAY}
-className="tooltip"
+          className="tooltip"
         />
         <div className='editor-toolbar__button-container'>
           {(this.props.editorMode === 'processing') && (

--- a/client/src/app/components/App/Shared/EditorComponents/EditorToolbar/EditorToolbar.jsx
+++ b/client/src/app/components/App/Shared/EditorComponents/EditorToolbar/EditorToolbar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactTooltip from 'react-tooltip';
 import ReactHtmlParser from 'react-html-parser';
 import PropTypes from 'prop-types';
 import axiosOrg from 'axios';
@@ -9,7 +10,7 @@ import PauseSVG from '../../../../../images/pause.svg';
 import PlaySVG from '../../../../../images/play.svg';
 import axios from '../../../../../utils/axios';
 import { ProcessingWarning, WorkspaceLanguageConfirmation } from '../../../../../constants/codeConstants.js';
-
+import * as descriptions from '../../../../../constants/imageDescConstants.js';
 import FileUpload from '../../FileUpload/FileUpload.jsx';
 
 require('./editorToolbar.scss');
@@ -21,6 +22,12 @@ class EditorToolbar extends React.Component {
       isFileUploadOpen: false,
       isFileUploading: false
     };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.files !== this.props.files) {
+      ReactTooltip.rebuild();
+    }
   }
 
   openFileUpload = () => {
@@ -82,6 +89,9 @@ class EditorToolbar extends React.Component {
   render() {
     return (
       <div className='editor-toolbar__container'>
+        <ReactTooltip
+          delayShow={descriptions.SHOW_DESC_DELAY}
+        />
         <div className='editor-toolbar__button-container'>
           {(this.props.editorMode === 'processing') && (
             <div
@@ -134,12 +144,14 @@ class EditorToolbar extends React.Component {
               if (this.props.isPlaying) { this.props.startCodeRefresh(); }
             }}
             data-test='play-sketch-button'
+            data-tip={descriptions.EDITOR_PLAY_DESC}
           >
             <PlaySVG alt='Run Code' />
           </button>
           <button
             className={`editor-toolbar__svg ${!this.props.isPlaying ? 'editor-toolbar--isPaused' : ''}`}
             onClick={this.props.stopCode}
+            data-tip={descriptions.EDITOR_STOP_DESC}
           >
             <PauseSVG alt='Pause Code' />
           </button>
@@ -157,10 +169,11 @@ class EditorToolbar extends React.Component {
             this.props.files.map((file, index) => {
               const isImage = 'externalLink' in file;
               return (
-                <li key={file.id} className='editor-toolbar__file'>
-                  <p className='editor-toolbar__file-name'>
-                    {file.name}
-                  </p>
+                <li
+                  key={file.id}
+                  className='editor-toolbar__file'
+                  data-tip={file.name}
+                >
                   <button
                     onClick={() => {
                       this.props.setCurrentFile(index);
@@ -187,6 +200,7 @@ class EditorToolbar extends React.Component {
                 className="editor-toolbar__file-button"
                 onClick={this.openFileUpload}
                 data-test='add-editor-image-button'
+                data-tip={descriptions.EDITOR_ADD_IMAGE_DESC}
               >
                 <i className="fas fa-plus"></i>
               </button>

--- a/client/src/app/components/App/Shared/EditorComponents/EditorToolbar/editorToolbar.scss
+++ b/client/src/app/components/App/Shared/EditorComponents/EditorToolbar/editorToolbar.scss
@@ -146,6 +146,7 @@
             color: $g8;
           }
           &-static {
+            overflow: hidden;
             background-color: $g6;
             color: $g3;
             border: $small-border solid $g7;
@@ -166,16 +167,6 @@
 
 
 .editor-toolbar {
-  &__file-name {
-    display: none;
-    position: absolute;
-    top: $editor-toolbar-height;
-    background: $g6;
-    border: $light-black $small-border solid;
-    width: fit-content;
-    padding: 0 $small-padding;
-    font-size: $small-font-size;
-  }
   &__image-upload-gif {
     margin: 0 auto;
   }
@@ -307,9 +298,6 @@
           &:hover, &--selected { // sass-lint:disable-line class-name-format
             border: none;
           }
-        }
-        &:hover .editor-toolbar__file-name {
-          display: block;
         }
       }
 

--- a/client/src/app/constants/imageDescConstants.js
+++ b/client/src/app/constants/imageDescConstants.js
@@ -1,0 +1,18 @@
+export const SHOW_DESC_DELAY = 500;
+
+export const EDITOR_PLAY_DESC = 'Run Code';
+export const EDITOR_STOP_DESC = 'Stop Code';
+export const EDITOR_TOGGLE_CONSOLE_DESC = 'Toggle Console';
+export const EDITOR_ADD_IMAGE_DESC = 'Add Image';
+
+export const WIDGET_DELETE_DESC = 'Delete';
+export const WIDGET_DRAG_DESC = 'Drag';
+export const WIDGET_DUPLICATE_DESC = 'Duplicate';
+
+export const WIDGET_NAV_DESC = 'Table of Contents';
+export const WIDGET_NAV_REFRESH_DESC = 'Refresh';
+export const WIDGET_NAV_CLOSE_DESC = 'Close';
+
+export const MAIN_TOOLBAR_SETTINGS_DESC = 'Settings';
+export const MAIN_TOOLBAR_ACCOUNT_DESC = 'Account';
+export const MAIN_TOOLBAR_TOOLBARTITLE_DESC = 'Title';

--- a/client/src/app/constants/imageDescConstants.js
+++ b/client/src/app/constants/imageDescConstants.js
@@ -6,7 +6,7 @@ export const EDITOR_TOGGLE_CONSOLE_DESC = 'Toggle Console';
 export const EDITOR_ADD_IMAGE_DESC = 'Add Image';
 
 export const WIDGET_DELETE_DESC = 'Delete';
-export const WIDGET_DRAG_DESC = 'Drag';
+export const WIDGET_DRAG_DESC = 'Drag and Drop';
 export const WIDGET_DUPLICATE_DESC = 'Duplicate';
 
 export const WIDGET_NAV_DESC = 'Table of Contents';

--- a/client/src/app/styles/sass/base.scss
+++ b/client/src/app/styles/sass/base.scss
@@ -43,3 +43,7 @@ button {
   letter-spacing: 1px;
   text-transform: uppercase;
 }
+
+.tooltip {
+  width: fit-content;
+}


### PR DESCRIPTION
This PR fixes #484 
Adds rollover text using (react-tooltip)[https://github.com/wwayne/react-tooltip] module to the following

Table of contents:
* Refresh
* Close
* Table of contents

Components:
* Duplicate
* Drag and Drop
* Delete

Main Toolbar:
* Settings
* Account
* Page Title

Editor:
* Run Code
* Stop Code
* Toggle Console
* Add Images
* File Names
<img width="305" alt="screen shot 2018-11-14 at 3 43 51 pm" src="https://user-images.githubusercontent.com/5505598/48476090-20b50100-e824-11e8-8a58-975addad1530.png">

Before your pull request is reviewed and merged, please ensure that:

* [x] there are no linting errors
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] **Make sure you have run the tests!!**

Thank you!
