### PR TITLE
#531 : add padding to bottom of table of contents

### DIFF
--- a/client/src/app/components/App/Navigation/navigation.scss
+++ b/client/src/app/components/App/Navigation/navigation.scss
@@ -43,12 +43,12 @@
     font-family: $sourceSansPro;
     width: $navigation-width;
     padding-right: $xlarge-padding;
-    height: calc(100% - #{$main-toolbar-height*2});
+    height: calc(100% - #{$main-toolbar-height*2} - #{$workspace-navbar-height});
     z-index: $z-index-layer-2;
     overflow-x: scroll;
     &--expanded {
       top: $main-toolbar-height;
-      height: calc(100% - #{$main-toolbar-height});
+      height: calc(100% - #{$main-toolbar-height} - #{$workspace-navbar-height});
     }
   }
   &__items {

--- a/client/src/app/components/App/Workspace/workspace.scss
+++ b/client/src/app/components/App/Workspace/workspace.scss
@@ -16,10 +16,7 @@
     width: 100%;
     z-index: $z-index-layer-3;
     background: $white;
-    height: $h2-line-height*1.2;
-    // transition-timing-function: ease;
-    // -webkit-transition: height 0.5s;
-    // transition: height 0.5s;
+    height: $workspace-navbar-height;
     &--open {
       height: 70vh;
     }

--- a/client/src/app/styles/sass/variables.scss
+++ b/client/src/app/styles/sass/variables.scss
@@ -134,6 +134,7 @@ $total-width: 816px;
 $warning-width: 200px;
 $widget-nav-height: 20px;
 $welcome-container-height: 500px;
+$workspace-navbar-height: 32px;
 
 //z-indexes
 $z-index-layer-0: 0;


### PR DESCRIPTION
fixes #531 - adds padding to the bottom of the table of contents. This is so that if there are a lot of items in the table of contents, the last few don't get cut off by the workspace nav bar.
Before your pull request is reviewed and merged, please ensure that:

* [x] there are no linting errors
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] **Make sure you have run the tests!!**

Thank you!
