### PR TITLE
 set temp user name in sign up

### DIFF
--- a/client/src/app/components/App/Modal/SignUp/PeblioSignUpForm.jsx
+++ b/client/src/app/components/App/Modal/SignUp/PeblioSignUpForm.jsx
@@ -57,7 +57,7 @@ class PeblioSignUpForm extends React.Component {
   submitSignUpUser = (event) => {
     const loginData = {
       mail: this.userMail ? this.userMail.value : this.props.guardianEmail,
-      name: this.props.name,
+      name: this.props.tempUsername,
       userType: this.props.userType,
       password: this.password.value,
       requiresGuardianConsent: this.props.requiresGuardianConsent,
@@ -74,7 +74,7 @@ class PeblioSignUpForm extends React.Component {
             action: 'Signup User',
             module: 'ui',
             level: 'INFO',
-            user: this.props.name
+            user: this.props.tempUsername
           };
           saveLog(log);
         })
@@ -97,7 +97,7 @@ class PeblioSignUpForm extends React.Component {
           userType={this.props.userType}
           requiresGuardianConsent={this.props.requiresGuardianConsent}
           guardianEmail={this.props.guardianEmail}
-          name={this.props.name}
+          name={this.props.tempUsername}
         />
         <div className="signup-modal__or-container">
           <hr className="signup-modal__or-line" />
@@ -166,7 +166,7 @@ PeblioSignUpForm.propTypes = {
   guardianEmail: PropTypes.string,
   requiresGuardianConsent: PropTypes.bool,
   userType: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  tempUsername: PropTypes.string.isRequired,
   studentBirthday: PropTypes.string
 };
 
@@ -183,7 +183,6 @@ function mapStateToProps(state) {
     userType: state.user.type,
     studentBirthday: state.user.studentBirthday,
     guardianEmail: state.user.guardianEmail,
-    name: state.user.name
   };
 }
 

--- a/client/src/app/components/App/Modal/SignUp/SignUp.jsx
+++ b/client/src/app/components/App/Modal/SignUp/SignUp.jsx
@@ -15,8 +15,13 @@ class SignUp extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      isUserTypeSelected: false
+      isUserTypeSelected: false,
+      tempUsername: ''
     };
+  }
+
+  componentWillMount() {
+    this.props.setNextScreen('');
   }
 
   componentWillUnmount() {
@@ -26,6 +31,12 @@ class SignUp extends React.Component {
   userTypeSelected = () => {
     this.setState({
       isUserTypeSelected: true
+    });
+  }
+
+  setTempUserName = (name) => {
+    this.setState({
+      tempUsername: name
     });
   }
 
@@ -77,7 +88,10 @@ class SignUp extends React.Component {
     return (
       <div className="signup-modal__content">
         {this.props.userType === 'student' && this.renderSignupScreenNumber(2)}
-        <SignUpUsername />
+        <SignUpUsername
+          setTempUserName={this.setTempUserName}
+          tempUsername={this.state.tempUsername}
+        />
       </div>
     );
   }
@@ -86,7 +100,9 @@ class SignUp extends React.Component {
     return (
       <div className="signup-modal__content">
         {this.props.userType === 'student' && this.renderSignupScreenNumber(3)}
-        <SignUpOption />
+        <SignUpOption
+          tempUsername={this.state.tempUsername}
+        />
       </div>
     );
   }
@@ -95,7 +111,9 @@ class SignUp extends React.Component {
     return (
       <div className="signup-modal__content">
         {this.props.userType === 'student' && this.renderSignupScreenNumber(3)}
-        <PeblioSignUpForm />
+        <PeblioSignUpForm
+          tempUsername={this.state.tempUsername}
+        />
       </div>
     );
   }

--- a/client/src/app/components/App/Modal/SignUp/SignUpOption.jsx
+++ b/client/src/app/components/App/Modal/SignUp/SignUpOption.jsx
@@ -52,7 +52,7 @@ class SignUpOption extends React.Component {
           userType={this.props.userType}
           requiresGuardianConsent={this.props.requiresGuardianConsent}
           guardianEmail={this.props.guardianEmail}
-          name={this.props.name}
+          name={this.props.tempUsername}
         />
         <div className="signup-modal__or-container">
           <hr className="signup-modal__or-line" />
@@ -86,7 +86,7 @@ SignUpOption.propTypes = {
   guardianEmail: PropTypes.string,
   requiresGuardianConsent: PropTypes.bool,
   userType: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
+  tempUsername: PropTypes.string.isRequired,
 };
 
 SignUpOption.defaultProps = {
@@ -101,7 +101,6 @@ function mapStateToProps(state) {
     userType: state.user.type,
     studentBirthday: state.user.studentBirthday,
     guardianEmail: state.user.guardianEmail,
-    name: state.user.name
   };
 }
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/client/src/app/components/App/Modal/SignUp/SignUpUsername.jsx
+++ b/client/src/app/components/App/Modal/SignUp/SignUpUsername.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import axios from '../../../../utils/axios';
-import { setUserName, setNextScreen } from '../../../../action/user.js';
+import { setNextScreen } from '../../../../action/user.js';
 
 class SignUpUsername extends React.Component {
   constructor(props) {
@@ -20,7 +20,7 @@ class SignUpUsername extends React.Component {
     })
       .then(() => {
         if (this.userName.value && this.userName.value !== '') {
-          this.props.setUserName(this.userName.value);
+          this.props.setTempUserName(this.userName.value);
           this.props.setNextScreen('SignupOption');
         }
       })
@@ -76,7 +76,7 @@ class SignUpUsername extends React.Component {
 }
 
 SignUpUsername.propTypes = {
-  setUserName: PropTypes.func.isRequired,
+  setTempUserName: PropTypes.func.isRequired,
   setNextScreen: PropTypes.func.isRequired
 };
 
@@ -85,7 +85,6 @@ function mapStateToProps() {
 }
 
 const mapDispatchToProps = dispatch => bindActionCreators({
-  setUserName,
   setNextScreen
 }, dispatch);
 


### PR DESCRIPTION
This PR ensures that when a user name is set during signup, it sets a temp state, as opposed to the redux store's user name.

Before your pull request is reviewed and merged, please ensure that:

* [x] there are no linting errors
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] **Make sure you have run the tests!!**

Thank you!
