### PR TITLE
get page details while duplicating

### DIFF
--- a/client/src/app/action/page.js
+++ b/client/src/app/action/page.js
@@ -115,30 +115,37 @@ export function loadPage(id, parentId, title, heading, description, layout, tags
   };
 }
 
-export function duplicatePage(title, heading, description, folder, editors, editorIndex, layout, tags, snapshotPath) {
+export function duplicatePage(id, folder) {
   return (dispatch) => {
-    const id = shortid.generate();
-    const data = {
-      id,
-      title: `${title}-Copy`,
-      heading,
-      description,
-      editors,
-      editorIndex,
-      layout,
-      tags,
-      snapshotPath
-    };
-    if (folder) {
-      data.folder = folder;
-    }
+    axios.get(`/pages/${id}`)
+      .then((res) => {
+        const pebl = res.data[0];
+        const id = shortid.generate();
+        const data = {
+          id,
+          title: `${pebl.title}-Copy`,
+          heading: pebl.heading,
+          description: pebl.description,
+          editors: pebl.editors,
+          editorIndex: pebl.editorIndex,
+          layout: pebl.layout,
+          tags: pebl.tags,
+          snapshotPath: pebl.snapshotPath
+        };
+        if (pebl.folder) {
+          data.folder = pebl.folder;
+        }
 
-    axios.post('/pages/save', data).then((response) => {
-      dispatch({
-        type: ActionTypes.DUPLICATE_PAGE,
-        page: response.data.page
+        axios.post('/pages/save', data).then((response) => {
+          dispatch({
+            type: ActionTypes.DUPLICATE_PAGE,
+            page: response.data.page
+          });
+        });
+      })
+      .catch((err) => {
+        console.log(err);
       });
-    });
   };
 }
 

--- a/client/src/app/components/App/Modal/PagesList/PageRow/PageRow.jsx
+++ b/client/src/app/components/App/Modal/PagesList/PageRow/PageRow.jsx
@@ -35,18 +35,11 @@ class PageRow extends Component {
   duplicatePage = (e) => {
     e.stopPropagation();
     const {
-      title,
-      heading,
-      description,
-      folder,
-      editors,
-      editorIndex,
-      layout,
-      tags,
-      snapshotPath
+      id,
+      folder
     } = this.props.page;
 
-    this.props.duplicatePage(title, heading, description, folder, editors, editorIndex, layout, tags, snapshotPath);
+    this.props.duplicatePage(id, folder);
   }
 
   handleClick = (e) => {

--- a/client/src/app/components/Shared/Documents/DocumentsView/Pages/Page.jsx
+++ b/client/src/app/components/Shared/Documents/DocumentsView/Pages/Page.jsx
@@ -55,18 +55,11 @@ class Page extends Component {
   duplicatePage = (e, page) => {
     e.stopPropagation();
     const {
-      title,
-      heading,
-      description,
-      folder,
-      editors,
-      editorIndex,
-      layout,
-      tags,
-      snapshotPath
+      id,
+      folder
     } = page;
 
-    this.props.duplicatePage(title, heading, description, folder, editors, editorIndex, layout, tags, snapshotPath);
+    this.props.duplicatePage(id, folder);
   }
 
   renamePage = (e, id) => {

--- a/server/src/routes/pageRoutes.js
+++ b/server/src/routes/pageRoutes.js
@@ -1,4 +1,4 @@
-const express = require('express');
+  const express = require('express');
 const pageRoutes = express.Router();
 import * as pageController from '../controllers/pageController';
 


### PR DESCRIPTION
In #761 - we removed unecessary information from fetchAllPages and this broke the duplicate function.
This PR is to ensure that page details of a page are retrived while duplicating.

Before your pull request is reviewed and merged, please ensure that:

* [x] there are no linting errors
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] **Make sure you have run the tests!!**

Thank you!
