### PR TITLE
Remove history button

### DIFF
--- a/client/src/app/components/App/MainToolbar/InsertToolbar/InsertToolbar.jsx
+++ b/client/src/app/components/App/MainToolbar/InsertToolbar/InsertToolbar.jsx
@@ -200,18 +200,20 @@ export class InsertToolbar extends React.Component {
             Image
           </button>
         </div>
-        <div className="insert-toolbar__container-right">
-          <button
-            onMouseDown={this.props.togglePageVersion}
-            onKeyDown={this.props.togglePageVersion}
-            id="elementButton"
-            className={`insert-toolbar__button
+        {this.props.canEdit && (
+          <div className="insert-toolbar__container-right">
+            <button
+              onMouseDown={this.props.togglePageVersion}
+              onKeyDown={this.props.togglePageVersion}
+              id="elementButton"
+              className={`insert-toolbar__button
               ${(this.props.isPageVersionOpen) ? 'insert-toolbar__button--highlighted' : ''}`}
-            data-test="insert-toolbar__show-page-version"
-          >
-            <HistorySVG alt="show page version" />
-          </button>
-        </div>
+              data-test="insert-toolbar__show-page-version"
+            >
+              <HistorySVG alt="show page version" />
+            </button>
+          </div>
+        )}
       </div>
     );
   }
@@ -224,11 +226,13 @@ InsertToolbar.propTypes = {
   addTextEditor: PropTypes.func.isRequired,
   addQuestionEditor: PropTypes.func.isRequired,
   addVideo: PropTypes.func.isRequired,
+  canEdit: PropTypes.bool.isRequired,
   isPageVersionOpen: PropTypes.bool.isRequired,
   togglePageVersion: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({
+  canEdit: state.user.canEdit,
   isPageVersionOpen: state.pageVersion.isPageVersionOpen
 });
 

--- a/client/src/app/components/App/Shared/EditorComponents/EditorFiles/EditorFile.jsx
+++ b/client/src/app/components/App/Shared/EditorComponents/EditorFiles/EditorFile.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Tooltip from 'react-tooltip-lite';
 import PropTypes from 'prop-types';
 
 const HTML_FILE_REGEX = /.+\.(html)$/i;

--- a/client/test/app/components/App/MainToolbar/InsertToolbar/InsertToolbar-test.js
+++ b/client/test/app/components/App/MainToolbar/InsertToolbar/InsertToolbar-test.js
@@ -21,6 +21,7 @@ describe('InsertToolbar', () => {
     togglePageVersionMock = sandbox.mock();
     props = {
       togglePageVersion: togglePageVersionMock,
+      canEdit: true
     };
   });
 


### PR DESCRIPTION
Currently, history button is visible even if you are not the owner of the page. This PR ensures that you can see the history button only if you own it or are not logged in (in which case history is not saved)

Before your pull request is reviewed and merged, please ensure that:

* [x] there are no linting errors
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] **Make sure you have run the tests!!**

Thank you!
