### PR TITLE
Allow Signup Modal to Open from Login Modal. This has been especially…

### DIFF
--- a/client/src/app/components/App/Modal/Login/Login.jsx
+++ b/client/src/app/components/App/Modal/Login/Login.jsx
@@ -6,7 +6,7 @@ import { bindActionCreators } from 'redux';
 
 import axios from '../../../../utils/axios';
 import { setUserName, setUserType, fetchCurrentUserForAppStartUp } from '../../../../action/user.js';
-import { closeLoginModal, viewForgotModal } from '../../../../action/mainToolbar.js';
+import { closeLoginModal, viewForgotModal, viewSignUpModal } from '../../../../action/mainToolbar.js';
 import GoogleLoginButton from '../../Shared/GoogleButton/GoogleLoginButton.jsx';
 import { saveLog } from '../../../../utils/log';
 
@@ -113,6 +113,15 @@ class Login extends React.Component {
             >
               forgot password?
             </button>
+            <button
+              className="login-modal__signup-link"
+              onClick={() => {
+                this.props.viewSignUpModal();
+                this.props.closeLoginModal();
+              }}
+            >
+              Sign Up
+            </button>
           </div>
         </form>
 
@@ -133,6 +142,7 @@ Login.propTypes = {
   setUserName: PropTypes.func.isRequired,
   setUserType: PropTypes.func.isRequired,
   viewForgotModal: PropTypes.func.isRequired,
+  viewSignUpModal: PropTypes.func.isRequired,
   fetchCurrentUserForAppStartUp: PropTypes.func.isRequired
 };
 
@@ -141,6 +151,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   setUserName,
   setUserType,
   viewForgotModal,
+  viewSignUpModal,
   fetchCurrentUserForAppStartUp
 }, dispatch);
 

--- a/client/src/app/components/App/Modal/Login/login.scss
+++ b/client/src/app/components/App/Modal/Login/login.scss
@@ -34,7 +34,7 @@
     @extend %modal__buttonholder;
   }
 
-  &__forgot-link {
+  &__forgot-link, &__signup-link {
     @extend %modal__link;
     margin: $large-margin 0;
     &:hover {

--- a/client/src/app/components/ClassRoom/MyClasses/MyClasses.jsx
+++ b/client/src/app/components/ClassRoom/MyClasses/MyClasses.jsx
@@ -59,7 +59,7 @@ const MyClasses = ({
     <React.Fragment>
       {
         dataLoading ? <GenericLoader /> : (
-          <main className="classroom">
+          <main className="classroom" data-test="classroom-test">
             <div className="classroom__header-area">
               <header
                 className="classroom__header-area__header"

--- a/tests/auth/login-test.js
+++ b/tests/auth/login-test.js
@@ -28,7 +28,7 @@ test('through the login form with a valid email and password', async (t) => {
     .expect(Selector('[data-test=account-button]').exists).ok();
 });
 
-test.only('through the login form with a invalid email and password should show error', async (t) => {
+test('through the login form with a invalid email and password should show error', async (t) => {
   await t
     .click(Selector('[data-test=close-modal]'))
     .click(Selector('[data-test=user-account__login-button]'))

--- a/tests/auth/studnet-signup-autologin-test.js
+++ b/tests/auth/studnet-signup-autologin-test.js
@@ -40,6 +40,31 @@ test('through the signup form with a valid email and password', async (t) => {
     .expect(Selector('[data-test=account-button]').exists).ok();
 });
 
+test('through the signup form from login modal on classroom page with a valid email and password', async (t) => {
+  await t
+    .navigateTo('/classroom')
+    .click(Selector('[data-test=close-modal]'))
+    .click(Selector('[data-test=user-account__signup-button]'))
+    .click(Selector('[data-test=signup-modal__radio-student]'))
+    .click(Selector('[data-test=signup-modal__checkbox]'))
+    .click(Selector('[data-test=signup-modal__button-next]'))
+    .click(monthSelect)
+    .click(monthOption.withText('Jan'))
+    .click(yearSelect)
+    .click(yearOption.withText('1992'))
+    .click(Selector('[data-test=signup-modal__button-next]'))
+    .typeText(Selector('[data-test=signup-modal__input-name]'), studentUser.name, { paste: true })
+    .click(Selector('[data-test=signup-modal__button-next]'))
+    .click(Selector('[data-test=signup-modal__button-peblio]'))
+    .typeText(Selector('[data-test=signup-modal__input-email]'), studentUser.email, { paste: true })
+    .typeText(Selector('[data-test=signup-modal__input-pswd]'), studentUser.password, { paste: true })
+    .typeText(Selector('[data-test=signup-modal__input-pswd-confirm]'), studentUser.password, { paste: true })
+    .click(Selector('[data-test=signup-modal__button-submit]'))
+    .wait(1000)
+    .expect(Selector('[data-test=account-button]').exists).ok()
+    .expect(Selector('[data-test=classroom-test]').exists).ok();
+});
+
 test('through the signup form shall show error when username already taken', async (t) => {
   const hashedPassword = await hashUserPassword(studentUser.password);
   await seedDB({


### PR DESCRIPTION
Allow Signup Modal to Open from Login Modal. This has been especially done to make it easy for students to land on Classrooms page and signup from there instead of clicking around

Before your pull request is reviewed and merged, please ensure that:

* [ ] there are no linting errors
* [ ] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [ ] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] **Make sure you have run the tests!!**
  * [ ] Integration test & Server unit tests - run `npm run allTest` from the server folder
  * [ ] Client unit test - run `npm run test` from client folder
  * [ ] End to End test - run `npm run test` from the root folder

Thank you!
